### PR TITLE
Feature/fin 043 be attaching

### DIFF
--- a/src/app/api/tracking-operation/create/route.ts
+++ b/src/app/api/tracking-operation/create/route.ts
@@ -4,6 +4,7 @@ import { AuthGuard } from '@backend/entities/user/infrastructure/auth.guard';
 import { getDefaultApiErrorFilter } from '../../shared/get-api-error-filter.util';
 import { createRoute } from '@backend/shared/utils/create-route.util';
 import { trackingOperationRepository } from '@backend/entities/tracking-operation/infrastructure/tracking-operation.repository';
+import { assertFitAttachConditions } from '../utils/assert-fit-attach-conditions.util';
 
 export const POST = createRoute({
   schema: TrackingOperationSchema.omit({ id: true }),
@@ -12,11 +13,20 @@ export const POST = createRoute({
   execute: async ({ context, body }) => {
     const userId = context as number;
 
-    const { description, ...restBody } = body;
+    const { description, attachedPlannedMonthEntryId, attachedPlannedRegEntryId, ...restBody } = body;
+
+    await assertFitAttachConditions({
+      attachedPlannedMonthEntryId: attachedPlannedMonthEntryId ?? null,
+      attachedPlannedRegEntryId: attachedPlannedRegEntryId ?? null,
+      userId,
+      date: restBody.date,
+    });
 
     const id = await trackingOperationRepository.createItem({
       ...restBody,
       description: description ?? null,
+      attachedPlannedMonthEntryId: attachedPlannedMonthEntryId ?? null,
+      attachedPlannedRegEntryId: attachedPlannedRegEntryId ?? null,
       userId,
     });
 

--- a/src/app/api/tracking-operation/create/route.ts
+++ b/src/app/api/tracking-operation/create/route.ts
@@ -20,6 +20,7 @@ export const POST = createRoute({
       attachedPlannedRegEntryId: attachedPlannedRegEntryId ?? null,
       userId,
       date: restBody.date,
+      category: restBody.category,
     });
 
     const id = await trackingOperationRepository.createItem({

--- a/src/app/api/tracking-operation/create/route.ts
+++ b/src/app/api/tracking-operation/create/route.ts
@@ -7,7 +7,7 @@ import { trackingOperationRepository } from '@backend/entities/tracking-operatio
 import { assertFitAttachConditions } from '../utils/assert-fit-attach-conditions.util';
 
 export const POST = createRoute({
-  schema: TrackingOperationSchema.omit({ id: true }),
+  schema: TrackingOperationSchema,
   contextFn: GetUserIdTransformer,
   guards: [AuthGuard],
   execute: async ({ context, body }) => {

--- a/src/app/api/tracking-operation/update/[id]/route.ts
+++ b/src/app/api/tracking-operation/update/[id]/route.ts
@@ -7,6 +7,7 @@ import { trackingOperationRepository } from '@backend/entities/tracking-operatio
 import { ExistTrackingOperationGuard } from '@backend/entities/tracking-operation/application/exist-tracking-operation.guard';
 import { OwnsTrackingOperationGuard } from '@backend/entities/tracking-operation/application/owns-tracking-operation.guard';
 import { getDefaultApiErrorFilter } from '../../../shared/get-api-error-filter.util';
+import { assertFitAttachConditions } from '../../utils/assert-fit-attach-conditions.util';
 
 export const PUT = createRoute({
   schema: TrackingOperationSchema.omit({ id: true }),
@@ -25,11 +26,20 @@ export const PUT = createRoute({
     const ownsError = OwnsTrackingOperationGuard(userId as number, op);
     if (ownsError) return ownsError;
 
-    const { description, ...restBody } = body;
+    const { description, attachedPlannedMonthEntryId, attachedPlannedRegEntryId, ...restBody } = body;
+
+    await assertFitAttachConditions({
+      attachedPlannedMonthEntryId: attachedPlannedMonthEntryId ?? null,
+      attachedPlannedRegEntryId: attachedPlannedRegEntryId ?? null,
+      userId,
+      date: restBody.date,
+    });
 
     await trackingOperationRepository.updateItem(id, {
       ...restBody,
       description: description ?? null,
+      attachedPlannedMonthEntryId: attachedPlannedMonthEntryId ?? null,
+      attachedPlannedRegEntryId: attachedPlannedRegEntryId ?? null,
       userId,
     });
 

--- a/src/app/api/tracking-operation/update/[id]/route.ts
+++ b/src/app/api/tracking-operation/update/[id]/route.ts
@@ -10,7 +10,7 @@ import { getDefaultApiErrorFilter } from '../../../shared/get-api-error-filter.u
 import { assertFitAttachConditions } from '../../utils/assert-fit-attach-conditions.util';
 
 export const PUT = createRoute({
-  schema: TrackingOperationSchema.omit({ id: true }),
+  schema: TrackingOperationSchema,
   paramsFn: (context) => ({
     id: GetIntegerParamPipe(context.id, 1),
   }),

--- a/src/app/api/tracking-operation/update/[id]/route.ts
+++ b/src/app/api/tracking-operation/update/[id]/route.ts
@@ -33,6 +33,7 @@ export const PUT = createRoute({
       attachedPlannedRegEntryId: attachedPlannedRegEntryId ?? null,
       userId,
       date: restBody.date,
+      category: restBody.category,
     });
 
     await trackingOperationRepository.updateItem(id, {

--- a/src/app/api/tracking-operation/utils/assert-fit-attach-conditions.util.ts
+++ b/src/app/api/tracking-operation/utils/assert-fit-attach-conditions.util.ts
@@ -50,7 +50,7 @@ async function assertAttachedFits<T extends HasBudgetPlan>(opts: {
     throw new AppError(notFoundMessage, 403);
   }
 
-  const isFitDate = exist.budgetPlan?.month === date.getMonth() && exist.budgetPlan?.year === date.getFullYear();
+  const isFitDate = exist.budgetPlan?.month === date.getUTCMonth() && exist.budgetPlan?.year === date.getUTCFullYear();
 
   if (!isFitDate) {
     throw new AppError(dateMismatchMessage, 403);

--- a/src/app/api/tracking-operation/utils/assert-fit-attach-conditions.util.ts
+++ b/src/app/api/tracking-operation/utils/assert-fit-attach-conditions.util.ts
@@ -4,12 +4,14 @@ import { monthEntryRepository } from '@backend/entities/month-entry/infrastructu
 import { AppError } from '@common/classes/app-error.class';
 import { plannedRegOpsBudgetRepository } from '@backend/entities/planned-reg-ops-budget/infrastructure/planned-reg-ops-budget.repository';
 import { type BudgetPlanOrm } from '@backend/entities/budget-plan/infrastructure/budget-plan.orm';
+import { type AllCategories } from '@common/enums/categories.enum';
 
 type FitAttachConditionsProps = {
   attachedPlannedMonthEntryId: number | null;
   attachedPlannedRegEntryId: number | null;
   userId: number;
   date: Date;
+  category: AllCategories;
 };
 
 type HasBudgetPlan = { id: number; budgetPlan?: BudgetPlanOrm };
@@ -19,14 +21,29 @@ async function assertAttachedFits<T extends HasBudgetPlan>(opts: {
   id: number;
   userId: number;
   date: Date;
+  category: AllCategories;
+  getCategory: (entity: T) => AllCategories | undefined;
+  relations?: FindOptionsRelations<T>;
   notFoundMessage: string;
   dateMismatchMessage: string;
+  categoryMismatchMessage: string;
 }): Promise<void> {
-  const { repository, id, userId, date, notFoundMessage, dateMismatchMessage } = opts;
+  const {
+    repository,
+    id,
+    userId,
+    date,
+    category,
+    getCategory,
+    relations,
+    notFoundMessage,
+    dateMismatchMessage,
+    categoryMismatchMessage,
+  } = opts;
 
   const exist = await repository.findOne({
     where: { budgetPlan: { userId }, id } as FindOptionsWhere<T>,
-    relations: { budgetPlan: true } as FindOptionsRelations<T>,
+    relations: { budgetPlan: true, ...(relations ?? {}) } as FindOptionsRelations<T>,
   });
 
   if (!exist) {
@@ -38,6 +55,10 @@ async function assertAttachedFits<T extends HasBudgetPlan>(opts: {
   if (!isFitDate) {
     throw new AppError(dateMismatchMessage, 403);
   }
+
+  if (getCategory(exist) !== category) {
+    throw new AppError(categoryMismatchMessage, 403);
+  }
 }
 
 export async function assertFitAttachConditions({
@@ -45,6 +66,7 @@ export async function assertFitAttachConditions({
   attachedPlannedMonthEntryId,
   date,
   userId,
+  category,
 }: FitAttachConditionsProps): Promise<void> {
   if (!isEmpty(attachedPlannedMonthEntryId) && !isEmpty(attachedPlannedRegEntryId)) {
     throw new AppError(
@@ -59,8 +81,11 @@ export async function assertFitAttachConditions({
       id: attachedPlannedMonthEntryId,
       userId,
       date,
+      category,
+      getCategory: (entry) => entry.category,
       notFoundMessage: 'Запис місячної операції з таким ID не існує або не належить користувачу',
       dateMismatchMessage: "Дата операції не відповідає місяцю, до якого прив'язана планова операція місяця",
+      categoryMismatchMessage: 'Категорія операції має співпадати з категорією прикріпленої планової операції місяця',
     });
   }
 
@@ -70,9 +95,14 @@ export async function assertFitAttachConditions({
       id: attachedPlannedRegEntryId,
       userId,
       date,
+      category,
+      getCategory: (row) => row.regularOperation?.category,
+      relations: { regularOperation: true },
       notFoundMessage: 'Запис регулярної операції з таким ID не існує або не належить користувачу',
       dateMismatchMessage:
         "Дата операції не відповідає місяцю, до якого прив'язана планова операція регулярного бюджету",
+      categoryMismatchMessage:
+        'Категорія операції має співпадати з категорією прикріпленої планової операції регулярного бюджету',
     });
   }
 }

--- a/src/app/api/tracking-operation/utils/assert-fit-attach-conditions.util.ts
+++ b/src/app/api/tracking-operation/utils/assert-fit-attach-conditions.util.ts
@@ -1,0 +1,78 @@
+import { type FindOptionsRelations, type FindOptionsWhere, type Repository } from 'typeorm';
+import { isEmpty } from '@common/utils/is-empty.util';
+import { monthEntryRepository } from '@backend/entities/month-entry/infrastructure/month-entry.repository';
+import { AppError } from '@common/classes/app-error.class';
+import { plannedRegOpsBudgetRepository } from '@backend/entities/planned-reg-ops-budget/infrastructure/planned-reg-ops-budget.repository';
+import { type BudgetPlanOrm } from '@backend/entities/budget-plan/infrastructure/budget-plan.orm';
+
+type FitAttachConditionsProps = {
+  attachedPlannedMonthEntryId: number | null;
+  attachedPlannedRegEntryId: number | null;
+  userId: number;
+  date: Date;
+};
+
+type HasBudgetPlan = { id: number; budgetPlan?: BudgetPlanOrm };
+
+async function assertAttachedFits<T extends HasBudgetPlan>(opts: {
+  repository: Repository<T>;
+  id: number;
+  userId: number;
+  date: Date;
+  notFoundMessage: string;
+  dateMismatchMessage: string;
+}): Promise<void> {
+  const { repository, id, userId, date, notFoundMessage, dateMismatchMessage } = opts;
+
+  const exist = await repository.findOne({
+    where: { budgetPlan: { userId }, id } as FindOptionsWhere<T>,
+    relations: { budgetPlan: true } as FindOptionsRelations<T>,
+  });
+
+  if (!exist) {
+    throw new AppError(notFoundMessage, 403);
+  }
+
+  const isFitDate = exist.budgetPlan?.month === date.getMonth() && exist.budgetPlan?.year === date.getFullYear();
+
+  if (!isFitDate) {
+    throw new AppError(dateMismatchMessage, 403);
+  }
+}
+
+export async function assertFitAttachConditions({
+  attachedPlannedRegEntryId,
+  attachedPlannedMonthEntryId,
+  date,
+  userId,
+}: FitAttachConditionsProps): Promise<void> {
+  if (!isEmpty(attachedPlannedMonthEntryId) && !isEmpty(attachedPlannedRegEntryId)) {
+    throw new AppError(
+      'Не можна прикріпити одночасно і планову операцію місяця, і планову операцію регулярного бюджету',
+      403,
+    );
+  }
+
+  if (!isEmpty(attachedPlannedMonthEntryId)) {
+    await assertAttachedFits({
+      repository: monthEntryRepository.repository,
+      id: attachedPlannedMonthEntryId,
+      userId,
+      date,
+      notFoundMessage: 'Запис місячної операції з таким ID не існує або не належить користувачу',
+      dateMismatchMessage: "Дата операції не відповідає місяцю, до якого прив'язана планова операція місяця",
+    });
+  }
+
+  if (!isEmpty(attachedPlannedRegEntryId)) {
+    await assertAttachedFits({
+      repository: plannedRegOpsBudgetRepository.repository,
+      id: attachedPlannedRegEntryId,
+      userId,
+      date,
+      notFoundMessage: 'Запис регулярної операції з таким ID не існує або не належить користувачу',
+      dateMismatchMessage:
+        "Дата операції не відповідає місяцю, до якого прив'язана планова операція регулярного бюджету",
+    });
+  }
+}

--- a/src/client/features/budget-plan/update-budget-plan.local.use-case.ts
+++ b/src/client/features/budget-plan/update-budget-plan.local.use-case.ts
@@ -61,10 +61,16 @@ export class UpdateBudgetPlanLocalUseCase extends TransactionalUseCase<UpdateBud
       }),
     );
 
-    await this.plannedRegOpsBudgetRepository.deleteByBudgetPlanId(currentBudgetPlan.id);
+    const currentJoinRows = await this.plannedRegOpsBudgetRepository.getByBudgetPlanId(currentBudgetPlan.id);
+    const currentRegIds = currentJoinRows.map((r) => r.regularOperationId);
+
+    const joinRowsToDelete = currentJoinRows.filter((r) => !plannedRegularEntryIds.includes(r.regularOperationId));
+    const regIdsToAdd = plannedRegularEntryIds.filter((id) => !currentRegIds.includes(id));
+
+    await Promise.all(joinRowsToDelete.map((r) => this.plannedRegOpsBudgetRepository.deleteItem(r.id)));
 
     await Promise.all(
-      plannedRegularEntryIds.map((regularOperationId) =>
+      regIdsToAdd.map((regularOperationId) =>
         this.plannedRegOpsBudgetRepository.createItem({ regularOperationId, budgetPlanId: currentBudgetPlan.id }),
       ),
     );

--- a/src/client/features/tracking-operation/tracking-creation-form/tracking-operation-form.hook.ts
+++ b/src/client/features/tracking-operation/tracking-creation-form/tracking-operation-form.hook.ts
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import {
   type TrackingOperationFormData,
-  TrackingOperationFormSchema,
+  TrackingOperationSchema,
 } from '@common/domains/tracking-operation/schema/tracking-operation.schema';
 import type { TrackingOperationRecord } from '@common/records/tracking-operation.record';
 import { TypeEntry } from '@common/enums/entry.enum';
@@ -15,7 +15,7 @@ export function useTrackingOperationForm(initialData?: TrackingOperationRecord, 
   const isEdit = !!initialData;
 
   const methods = useForm<TrackingOperationFormData>({
-    resolver: zodResolver(TrackingOperationFormSchema) as never,
+    resolver: zodResolver(TrackingOperationSchema) as never,
     defaultValues: {
       title: initialData?.title ?? '',
       description: initialData?.description,

--- a/src/common/domains/tracking-operation/schema/tracking-operation.schema.ts
+++ b/src/common/domains/tracking-operation/schema/tracking-operation.schema.ts
@@ -10,7 +10,6 @@ const TrackingOperationTypes = [TypeEntry.Income, TypeEntry.Expense] as const;
 
 export const TrackingOperationSchema = z
   .object({
-    id: z.number().int({ message: 'ID має бути цілим числом' }).min(1, { message: 'ID не може бути менше 1' }),
     title: z
       .string()
       .min(1, { message: "Назва обов'язкова" })
@@ -72,6 +71,4 @@ export const TrackingOperationPaginationSchema = {
   }),
 };
 
-export const TrackingOperationFormSchema = TrackingOperationSchema.omit({ id: true });
-
-export type TrackingOperationFormData = z.infer<typeof TrackingOperationFormSchema>;
+export type TrackingOperationFormData = z.infer<typeof TrackingOperationSchema>;

--- a/src/common/domains/tracking-operation/schema/tracking-operation.schema.ts
+++ b/src/common/domains/tracking-operation/schema/tracking-operation.schema.ts
@@ -4,23 +4,41 @@ import { AllCategoryValues, ExpenseCategories } from '@common/enums/categories.e
 import { createPaginatedSchema } from '@common/utils/create-paginated-schema.util';
 import { getDate } from '@common/utils/get-date.util';
 import { dateField } from '@common/schema-fields/date-required-field.schema';
+import { isEmpty } from '@common/utils/is-empty.util';
 
 const TrackingOperationTypes = [TypeEntry.Income, TypeEntry.Expense] as const;
 
-export const TrackingOperationSchema = z.object({
-  id: z.number().int({ message: 'ID має бути цілим числом' }).min(1, { message: 'ID не може бути менше 1' }),
-  title: z
-    .string()
-    .min(1, { message: "Назва обов'язкова" })
-    .max(20, { message: 'Назва не може бути довшою за 20 символів' }),
-  description: z.string().max(100, { message: 'Опис не може бути довшим за 100 символів' }).nullable().optional(),
-  type: z.enum(TrackingOperationTypes, {
-    message: 'Тип має бути expense або income',
-  }),
-  date: dateField("Обов'язкова дата"),
-  sum: z.coerce.number({ message: 'Сума має бути числом' }).min(1, { message: 'Сума має бути не менше 1' }),
-  category: z.enum(AllCategoryValues).default(ExpenseCategories.Misc),
-});
+export const TrackingOperationSchema = z
+  .object({
+    id: z.number().int({ message: 'ID має бути цілим числом' }).min(1, { message: 'ID не може бути менше 1' }),
+    title: z
+      .string()
+      .min(1, { message: "Назва обов'язкова" })
+      .max(20, { message: 'Назва не може бути довшою за 20 символів' }),
+    description: z.string().max(100, { message: 'Опис не може бути довшим за 100 символів' }).nullable().optional(),
+    type: z.enum(TrackingOperationTypes, {
+      message: 'Тип має бути expense або income',
+    }),
+    date: dateField("Обов'язкова дата"),
+    sum: z.coerce.number({ message: 'Сума має бути числом' }).min(1, { message: 'Сума має бути не менше 1' }),
+    category: z.enum(AllCategoryValues).default(ExpenseCategories.Misc),
+    attachedPlannedRegEntryId: z
+      .int({ message: 'ID прикріпленої планової операції має бути цілим числом' })
+      .nullable()
+      .optional(),
+    attachedPlannedMonthEntryId: z
+      .int({ message: 'ID прикріпленої планової операції має бути цілим числом' })
+      .nullable()
+      .optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (!isEmpty(data.attachedPlannedMonthEntryId) && !isEmpty(data.attachedPlannedRegEntryId)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Не можна прикріпити одночасно і планову операцію місяця, і планову операцію регулярного бюджету',
+      });
+    }
+  });
 
 export const TrackingOperationFilterSchema = z
   .object({

--- a/src/common/records/tracking-operation.record.ts
+++ b/src/common/records/tracking-operation.record.ts
@@ -9,4 +9,6 @@ export interface TrackingOperationRecord extends DefaultTableColumns {
   date: Date;
   sum: number;
   category: AllCategories;
+  attachedPlannedRegEntryId?: number | null;
+  attachedPlannedMonthEntryId?: number | null;
 }

--- a/src/server/database/migrations.ts
+++ b/src/server/database/migrations.ts
@@ -1,4 +1,9 @@
 import { CreateTotpOrm1779620534129 } from '@backend/database/migrations/1779620534129-CreateTotpOrm';
 import { CreatePlannedRegOpsBudgetOrm1779749954455 } from '@backend/database/migrations/1779749954455-CreatePlannedRegOpsBudgetOrm';
+import { AddPlannedRegOpsBudgetAndTrackingAttachments1779821472804 } from '@backend/database/migrations/1779821472804-AddPlannedRegOpsBudgetAndTrackingAttachments';
 
-export const Migrations = [CreateTotpOrm1779620534129, CreatePlannedRegOpsBudgetOrm1779749954455];
+export const Migrations = [
+  CreateTotpOrm1779620534129,
+  CreatePlannedRegOpsBudgetOrm1779749954455,
+  AddPlannedRegOpsBudgetAndTrackingAttachments1779821472804,
+];

--- a/src/server/database/migrations/1779821472804-AddPlannedRegOpsBudgetAndTrackingAttachments.ts
+++ b/src/server/database/migrations/1779821472804-AddPlannedRegOpsBudgetAndTrackingAttachments.ts
@@ -1,0 +1,23 @@
+import { type MigrationInterface, type QueryRunner } from 'typeorm';
+
+export class AddPlannedRegOpsBudgetAndTrackingAttachments1779821472804 implements MigrationInterface {
+  name = 'AddPlannedRegOpsBudgetAndTrackingAttachments1779821472804';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "tracking-operation" ADD "attachedPlannedRegEntryId" integer`);
+    await queryRunner.query(`ALTER TABLE "tracking-operation" ADD "attachedPlannedMonthEntryId" integer`);
+    await queryRunner.query(
+      `ALTER TABLE "tracking-operation" ADD CONSTRAINT "FK_5855fcabedb7f4688273f1fbe1c" FOREIGN KEY ("attachedPlannedRegEntryId") REFERENCES "planned-reg-ops-budget"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "tracking-operation" ADD CONSTRAINT "FK_a90a8098a2fcc622c8d6d10bd82" FOREIGN KEY ("attachedPlannedMonthEntryId") REFERENCES "month_entry_orm"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "tracking-operation" DROP CONSTRAINT "FK_a90a8098a2fcc622c8d6d10bd82"`);
+    await queryRunner.query(`ALTER TABLE "tracking-operation" DROP CONSTRAINT "FK_5855fcabedb7f4688273f1fbe1c"`);
+    await queryRunner.query(`ALTER TABLE "tracking-operation" DROP COLUMN "attachedPlannedMonthEntryId"`);
+    await queryRunner.query(`ALTER TABLE "tracking-operation" DROP COLUMN "attachedPlannedRegEntryId"`);
+  }
+}

--- a/src/server/entities/month-entry/infrastructure/month-entry.orm.ts
+++ b/src/server/entities/month-entry/infrastructure/month-entry.orm.ts
@@ -1,7 +1,8 @@
 import type { MonthEntry } from '@common/records/month-entry.record';
-import { Column, Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from 'typeorm';
 import { BasicEntryOrm } from '@backend/entities/basic-entry/basic-entry.orm';
 import { type BudgetPlanOrm } from '@backend/entities/budget-plan/infrastructure/budget-plan.orm';
+import { type TrackingOperationOrm } from '@backend/entities/tracking-operation/infrastructure/tracking-operation.orm';
 
 @Entity('month_entry_orm')
 export class MonthEntryOrm extends BasicEntryOrm implements MonthEntry {
@@ -17,4 +18,7 @@ export class MonthEntryOrm extends BasicEntryOrm implements MonthEntry {
   @ManyToOne('BudgetPlanOrm', 'otherEntries', { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'budgetPlanId' })
   budgetPlan?: BudgetPlanOrm;
+
+  @OneToMany('TrackingOperationOrm', 'attachedPlannedMonthEntry')
+  attachedTrackedOperations?: TrackingOperationOrm[];
 }

--- a/src/server/entities/planned-reg-ops-budget/infrastructure/planned-reg-ops-budget.orm.ts
+++ b/src/server/entities/planned-reg-ops-budget/infrastructure/planned-reg-ops-budget.orm.ts
@@ -1,8 +1,9 @@
 import { DefaultTableColumnsOrm } from '@backend/database/default-table-columns.orm';
-import { Column, Entity, JoinColumn, ManyToOne, Unique } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany, Unique } from 'typeorm';
 import type { BudgetPlanOrm } from '@backend/entities/budget-plan/infrastructure/budget-plan.orm';
 import type { RegularEntryOrm } from '@backend/entities/regular-entry/infrastructure/regular-entry.orm';
 import type { PlannedRegOpsBudgetRecord } from '@common/records/planned-reg-ops-budget.record';
+import type { TrackingOperationOrm } from '@backend/entities/tracking-operation/infrastructure/tracking-operation.orm';
 
 @Entity('planned-reg-ops-budget')
 @Unique(['regularOperationId', 'budgetPlanId'])
@@ -20,4 +21,7 @@ export class PlannedRegOpsBudgetOrm extends DefaultTableColumnsOrm implements Pl
   @ManyToOne('BudgetPlanOrm', 'plannedRegularEntries', { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'budgetPlanId' })
   budgetPlan?: BudgetPlanOrm;
+
+  @OneToMany('TrackingOperationOrm', 'attachedPlannedRegEntry')
+  attachedTrackedOperations?: TrackingOperationOrm[];
 }

--- a/src/server/entities/tracking-operation/infrastructure/tracking-operation.orm.ts
+++ b/src/server/entities/tracking-operation/infrastructure/tracking-operation.orm.ts
@@ -4,6 +4,8 @@ import { type TrackingOperationRecord } from '@common/records/tracking-operation
 import { TypeEntry } from '@common/enums/entry.enum';
 import { type AllCategories, AllCategoryValues, ExpenseCategories } from '@common/enums/categories.enum';
 import { type UserOrm } from '@backend/entities/user/infrastructure/user.orm';
+import type { PlannedRegOpsBudgetOrm } from '@backend/entities/planned-reg-ops-budget/infrastructure/planned-reg-ops-budget.orm';
+import { type MonthEntryOrm } from '@backend/entities/month-entry/infrastructure/month-entry.orm';
 
 @Entity('tracking-operation')
 export class TrackingOperationOrm extends DefaultTableColumnsOrm implements TrackingOperationRecord {
@@ -40,7 +42,21 @@ export class TrackingOperationOrm extends DefaultTableColumnsOrm implements Trac
   @Column({ type: 'int' })
   userId!: number;
 
+  @Column({ type: 'int', nullable: true })
+  attachedPlannedRegEntryId?: number | null;
+
+  @Column({ type: 'int', nullable: true })
+  attachedPlannedMonthEntryId?: number | null;
+
   @ManyToOne('UserOrm', 'trackingOperations', { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'userId' })
   user?: UserOrm;
+
+  @ManyToOne('PlannedRegOpsBudgetOrm', 'attachedTrackedOperations', { onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'attachedPlannedRegEntryId' })
+  attachedPlannedRegEntry?: PlannedRegOpsBudgetOrm;
+
+  @ManyToOne('MonthEntryOrm', 'attachedTrackedOperations', { onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'attachedPlannedMonthEntryId' })
+  attachedPlannedMonthEntry?: MonthEntryOrm;
 }

--- a/src/server/features/budget-plan/update-budget-plan.api.use-case.ts
+++ b/src/server/features/budget-plan/update-budget-plan.api.use-case.ts
@@ -102,10 +102,11 @@ export class UpdateBudgetPlanApiUseCase extends TransactionalUseCase<UpdateBudge
     }
 
     const currentJoinRows = await this.plannedRegOpsBudgetRepository.repository.findBy({ budgetPlanId });
-    const currentRegIds = currentJoinRows.map((r) => r.regularOperationId);
+    const currentRegIds = new Set(currentJoinRows.map((r) => r.regularOperationId));
+    const uniquePlannedIdsSet = new Set(uniquePlannedIds);
 
-    const joinRowsToDelete = currentJoinRows.filter((r) => !uniquePlannedIds.includes(r.regularOperationId));
-    const regIdsToAdd = uniquePlannedIds.filter((id) => !currentRegIds.includes(id));
+    const joinRowsToDelete = currentJoinRows.filter((r) => !uniquePlannedIdsSet.has(r.regularOperationId));
+    const regIdsToAdd = uniquePlannedIds.filter((id) => !currentRegIds.has(id));
 
     if (joinRowsToDelete.length > 0) {
       await this.plannedRegOpsBudgetRepository.repository.delete(joinRowsToDelete.map((r) => r.id));

--- a/src/server/features/budget-plan/update-budget-plan.api.use-case.ts
+++ b/src/server/features/budget-plan/update-budget-plan.api.use-case.ts
@@ -87,18 +87,28 @@ export class UpdateBudgetPlanApiUseCase extends TransactionalUseCase<UpdateBudge
       await this.monthEntryRepository.repository.save(newEntries);
     }
 
-    await this.plannedRegOpsBudgetRepository.repository.delete({ budgetPlanId });
+    const currentJoinRows = await this.plannedRegOpsBudgetRepository.repository.findBy({ budgetPlanId });
+    const currentRegIds = currentJoinRows.map((r) => r.regularOperationId);
+
+    const joinRowsToDelete = currentJoinRows.filter((r) => !plannedRegularEntryIds.includes(r.regularOperationId));
+    const regIdsToAdd = plannedRegularEntryIds.filter((id) => !currentRegIds.includes(id));
+
+    if (joinRowsToDelete.length > 0) {
+      await this.plannedRegOpsBudgetRepository.repository.delete(joinRowsToDelete.map((r) => r.id));
+    }
 
     await this.budgetPlanRepository.repository.save({
       ...data,
       id: budgetPlanId,
     });
 
-    await this.plannedRegOpsBudgetRepository.repository.save(
-      plannedRegularEntryIds.map((id) =>
-        this.plannedRegOpsBudgetRepository.repository.create({ regularOperationId: id, budgetPlanId }),
-      ),
-    );
+    if (regIdsToAdd.length > 0) {
+      await this.plannedRegOpsBudgetRepository.repository.save(
+        regIdsToAdd.map((id) =>
+          this.plannedRegOpsBudgetRepository.repository.create({ regularOperationId: id, budgetPlanId }),
+        ),
+      );
+    }
 
     return true as const;
   }


### PR DESCRIPTION
# Title
FIN-043 PART 2

## Type
- [x] Feature
- [ ] Bug

## Description
Added API to attach tracking operation to month or regular entry in budget plan

## Media
Screenshots or videos demonstrating the changes

## Check list
- [x] Self-reviewed
- [ ] Added unit tests
- [x] The code doesn't have new warnings and errors
- [x] Passed ESLint / Prettier checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tracking operations can now be attached to planned budget entries (either regular or monthly entries).
  * Added validation to prevent simultaneous attachment to multiple types of planned entries on any single operation.

* **Performance Improvements**
  * Budget plan updates now apply only incremental modifications to stored data instead of replacing entire datasets, improving overall efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oleksandriia-it-team/finman/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->